### PR TITLE
Fix __updateValue in QDatetimePicker.js

### DIFF
--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -126,7 +126,7 @@ export default function ({ ssrContext }) {
         return ['time', 'datetime'].indexOf(this.mode) !== -1
       },
       intlLocale () {
-        var calendarva = 'gregory'
+        var calendar = 'gregory'
         switch (this.calendar) {
           case 'gregorian': calendar = 'gregory'; break
           case 'persian': calendar = 'persian'; break

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -126,7 +126,7 @@ export default function ({ ssrContext }) {
         return ['time', 'datetime'].indexOf(this.mode) !== -1
       },
       intlLocale () {
-        var calendarva'gregory'
+        var calendarva = 'gregory'
         switch (this.calendar) {
           case 'gregorian': calendar = 'gregory'; break
           case 'persian': calendar = 'persian'; break

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -126,7 +126,7 @@ export default function ({ ssrContext }) {
         return ['time', 'datetime'].indexOf(this.mode) !== -1
       },
       intlLocale () {
-        var calendar = 'gregory'
+        var calendarva'gregory'
         switch (this.calendar) {
           case 'gregorian': calendar = 'gregory'; break
           case 'persian': calendar = 'persian'; break
@@ -275,7 +275,7 @@ export default function ({ ssrContext }) {
             }
           }
         } else {
-          this.values.input = this.original.input = value
+          this.values.input = this.original.input = null
           this.values.date = this.original.date = ''
           this.values.time = this.original.time = ''
         }

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -275,7 +275,7 @@ export default function ({ ssrContext }) {
             }
           }
         } else {
-          this.values.input = this.original.input = null
+          this.values.input = this.original.input = ''
           this.values.date = this.original.date = ''
           this.values.time = this.original.time = ''
         }


### PR DESCRIPTION
When this.value is not set, the default value must be null. Currently being set to the value of the variable "value" ("value" in this case is a reserved word)

![image](https://user-images.githubusercontent.com/24731835/61317628-c4064d80-a7d9-11e9-8433-ab0455fe0994.png)
