### PR TITLE
Fix: keep date/time when filling input

### DIFF
--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -287,6 +287,7 @@ export default function ({ ssrContext }) {
           this.$emit('input', '')
         } else {
           let proporsal = date.quasar({ 
+            base: this.value,
             masked: value,
             ampm: this.format24h ? void 0 : this.values.suffix,
             mode: this.mode,

--- a/src/services/date.js
+++ b/src/services/date.js
@@ -22,22 +22,22 @@ export function parse ({ proporsal, withSeconds }) {
   return { success: false, quasar: '', iso: '' }
 }
 
-export function getDefault ({ mode }) {
-  let meta, quasar
+export function getDefault ({ base, mode }) {
+  let meta, quasar, baseDate
   if (mode === 'time') {
-    meta = {
-      year: '1970',
-      month: '01',
-      day: '01',
-    }
+		baseDate = new Date(base || null)
   } else {
-    let today = new Date()
-    meta = {
-      year: ('' + today.getFullYear()).padStart(4, '0'),
-      month: ('' + (today.getMonth() + 1)).padStart(2, '0'),
-      day: ('' + today.getDate()).padStart(2, '0'),
-    }
-  }
+		if (base) {
+			baseDate = new Date(base)
+		} else {
+			baseDate = new Date()
+		}
+	}
+	meta = {
+		year: ('' + baseDate.getFullYear()).padStart(4, '0'),
+		month: ('' + (baseDate.getMonth() + 1)).padStart(2, '0'),
+		day: ('' + baseDate.getDate()).padStart(2, '0'),
+	}
   quasar = `${meta.year}/${meta.month}/${meta.day}`
   return {
     meta,
@@ -45,10 +45,17 @@ export function getDefault ({ mode }) {
   }
 }
 
-export function quasar ({ masked, ampm, mode, metas, masks }) {
-  let today = getDefault({ mode })
+export function quasar ({ base, masked, ampm, mode, metas, masks }) {
+  let today = getDefault({ base, mode })
   let date = today.quasar
-  let time = '00:00:00'
+	let time = '00:00:00'
+	if (base) {
+		const baseDate = new Date(base)
+    let hour = (baseDate.getHours() + '').padStart(2, '0')
+    let minute = (baseDate.getMinutes() + '').padStart(2, '0')
+		let second = (baseDate.getSeconds() + '').padStart(2, '0')
+    time = `${hour}:${minute}:${second}`
+	}
   let maskedDate, maskedTime
   switch (mode) {
     case 'date':

--- a/src/services/date.js
+++ b/src/services/date.js
@@ -25,19 +25,19 @@ export function parse ({ proporsal, withSeconds }) {
 export function getDefault ({ base, mode }) {
   let meta, quasar, baseDate
   if (mode === 'time') {
-		baseDate = new Date(base || null)
+    baseDate = new Date(base || '1970-01-01')
   } else {
-		if (base) {
-			baseDate = new Date(base)
-		} else {
-			baseDate = new Date()
-		}
-	}
-	meta = {
-		year: ('' + baseDate.getFullYear()).padStart(4, '0'),
-		month: ('' + (baseDate.getMonth() + 1)).padStart(2, '0'),
-		day: ('' + baseDate.getDate()).padStart(2, '0'),
-	}
+    if (base) {
+      baseDate = new Date(base)
+    } else {
+      baseDate = new Date()
+    }
+  }
+  meta = {
+    year: ('' + baseDate.getFullYear()).padStart(4, '0'),
+    month: ('' + (baseDate.getMonth() + 1)).padStart(2, '0'),
+    day: ('' + baseDate.getDate()).padStart(2, '0'),
+  }
   quasar = `${meta.year}/${meta.month}/${meta.day}`
   return {
     meta,
@@ -48,14 +48,14 @@ export function getDefault ({ base, mode }) {
 export function quasar ({ base, masked, ampm, mode, metas, masks }) {
   let today = getDefault({ base, mode })
   let date = today.quasar
-	let time = '00:00:00'
-	if (base) {
-		const baseDate = new Date(base)
+  let time = '00:00:00'
+  if (base) {
+    const baseDate = new Date(base)
     let hour = (baseDate.getHours() + '').padStart(2, '0')
     let minute = (baseDate.getMinutes() + '').padStart(2, '0')
-		let second = (baseDate.getSeconds() + '').padStart(2, '0')
+    let second = (baseDate.getSeconds() + '').padStart(2, '0')
     time = `${hour}:${minute}:${second}`
-	}
+  }
   let maskedDate, maskedTime
   switch (mode) {
     case 'date':


### PR DESCRIPTION
getDefault() and quasar() accept a "base", which, if set, replaces the
default "1970-01-01 00:00:00".

refs #39