### PR TITLE
Popup hide emit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ QDatetimePicker (quasar-app-extension-qdatetimepicker)
 QDatetimePicker is a `UI App Extension` for [Quasar Framework v1](https://v1.quasar-framework.org/). It will not work with legacy versions of Quasar Framework.
 
 This work is currently in `beta` and minor changes may still happen. Your help with testing is greatly appreciated.
-# Bugs
-1. When the picker popup hides because the user Cancels or Blurs off, the display date should return to the initial value. Otherwise, they can change the date and/or time then cancel and the display date shows the changed date/time even if it was not Set
 
 # Notes
 Minimum required version is Quasar 1.0.0.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ QDatetimePicker (quasar-app-extension-qdatetimepicker)
 QDatetimePicker is a `UI App Extension` for [Quasar Framework v1](https://v1.quasar-framework.org/). It will not work with legacy versions of Quasar Framework.
 
 This work is currently in `beta` and minor changes may still happen. Your help with testing is greatly appreciated.
+# Bugs
+1. When the picker popup hides because the user Cancels or Blurs off, the display date should return to the initial value. Otherwise, they can change the date and/or time then cancel and the display date shows the changed date/time even if it was not Set
 
 # Notes
 Minimum required version is Quasar 1.0.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "quasar-app-extension-qdatetimepicker",
+  "version": "1.0.0-rc.17",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "quasar": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-1.15.0.tgz",
+      "integrity": "sha512-GTIz/8AgzpHKPsbrQfO32dPPEGjDSFDWRE4dvt3AHh2LtRRAE5QJwPMqCy11GYGhyLMeZaRl76AuCUVb0BYTzA==",
+      "dev": true
+    },
+    "vue": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==",
+      "dev": true
+    }
+  }
+}

--- a/qdatetimepicker.code-workspace
+++ b/qdatetimepicker.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -335,25 +335,27 @@ export default function ({ ssrContext }) {
       },
       onSetClick () {
         let today = date.getDefault({ mode: this.mode })
+        // MH added
         let commitedChanges = true
         switch (true) {
           case this.mode === 'date':
             this.original.date = this.values.date
-            this.$refs.popup.hide()
+            // this.$refs.popup.hide() // MH removed
             break
           case this.mode === 'time':
             this.original.time = this.values.time
-            this.$refs.popup.hide()
+            // this.$refs.popup.hide() // MH removed
             break
           case this.mode === 'datetime' && this.tab === 'date':
             this.original.date = this.values.date
             this.tab = 'time'
+            // MH added
             commitedChanges = false
             break
           case this.mode === 'datetime' && this.tab === 'time':
             this.original.date = this.values.date
             this.original.time = this.values.time
-            this.$refs.popup.hide()
+            // this.$refs.popup.hide() // MH removed
             break
         }
         let dateValue = this.original.date // || today.quasar
@@ -362,7 +364,7 @@ export default function ({ ssrContext }) {
           dateValue = today.quasar
         }
         if (!timeValue && dateValue) {
-          timeValue =  (this.withSeconds ? '00:00:00' : '00:00')
+          timeValue = (this.withSeconds ? '00:00:00' : '00:00')
         }
         if (dateValue && timeValue) {
           let proporsal = `${dateValue} ${timeValue}`
@@ -370,17 +372,28 @@ export default function ({ ssrContext }) {
           if (parsed.success) {
             this.__updateDates(parsed)
           }
-          if (commitedChanges) {
-            this.$emit('commit', parsed)
-          }
+        }
+        // MH Bug Fix:
+        // Moved the popup.hide() to here so the inputs are updated above BEFORE we close the popup.
+        // Then, at the time you hear the events when the popup closes, you know the field values
+        // are the same as in the picker.
+        if (commitedChanges) {
+          this.$refs.popup.hide(true) // MH: added the commit boolean. See: onPopupHide()
         }
       },
       onPopupShow () {
         this.tab = 'date'
       },
-      onPopupHide () {
+      onPopupHide (commit) {
         this.values.date = this.original.date
         this.values.time = this.original.time
+
+        // MH added this (and the commit arg):
+        if (commit) {
+          this.$emit('commit')
+        } else {
+          this.$emit('cancel')
+        }
       },
       toggleSuffix () {
         this.values.suffix = this.values.suffix === 'PM' ? 'AM' : 'PM'

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -201,9 +201,9 @@ export default function ({ ssrContext }) {
         immediate: true,
         handler () {
           if (!this.value) {
-            this.standard = this.defaultStandard 
+            this.standard = this.defaultStandard
           } else {
-            let standard = this.defaultStandard 
+            let standard = this.defaultStandard
             switch (true) {
               case this.value.indexOf('-') !== -1: standard = 'iso'; break
               case this.value.indexOf('/') !== -1: standard = 'quasar'; break
@@ -311,7 +311,7 @@ export default function ({ ssrContext }) {
         if (!value) {
           this.$emit('input', '')
         } else {
-          let proporsal = date.quasar({ 
+          let proporsal = date.quasar({
             base: this.value,
             masked: value,
             ampm: this.format24h ? void 0 : this.values.suffix,
@@ -335,6 +335,7 @@ export default function ({ ssrContext }) {
       },
       onSetClick () {
         let today = date.getDefault({ mode: this.mode })
+        let commitedChanges = true
         switch (true) {
           case this.mode === 'date':
             this.original.date = this.values.date
@@ -347,6 +348,7 @@ export default function ({ ssrContext }) {
           case this.mode === 'datetime' && this.tab === 'date':
             this.original.date = this.values.date
             this.tab = 'time'
+            commitedChanges = false
             break
           case this.mode === 'datetime' && this.tab === 'time':
             this.original.date = this.values.date
@@ -367,6 +369,9 @@ export default function ({ ssrContext }) {
           let parsed = date.parse({ proporsal, withSeconds: this.withSeconds })
           if (parsed.success) {
             this.__updateDates(parsed)
+          }
+          if (commitedChanges) {
+            this.$emit('commit', parsed)
           }
         }
       },


### PR DESCRIPTION
Again, I hope I am doing this PR correctly.

With the `datetime` mode, when you "set" the date and move to the time, the input value gets updated. If you then click Cancel, the changed date does not revert to the original one because the set on the date sets original to the new date (in  `onSetClick()` ) so it has lost the original.

Also, in my app, I needed to know when the user did click Set and did click Cancel (or blurred away) because I am using your picker in a custom composite field with 2 datetime pickers. and needed to take definitive action.

So, I have made some suggestions via this PR to make all that work. I left comments in the code (`QDatetimePicker.js`) which you will see to explain my thinking.

Thanks again for your work,
Murray