### PR TITLE
Do not add time or date when in date or time mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,41 @@
-################################################################################
-# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
-################################################################################
-
 /.vs
 /yarn.lock
 /node_modules
 .DS_Store
 test/app/yarn.lock
+
+
+.DS_Store
+.thumbs.db
+node_modules
+
+# Quasar core related directories
+.quasar
+/dist
+
+# Cordova related directories and files
+/src-cordova/node_modules
+/src-cordova/platforms
+/src-cordova/plugins
+/src-cordova/www
+
+# Capacitor related directories and files
+/src-capacitor/www
+/src-capacitor/node_modules
+
+# BEX related directories and files
+/src-bex/www
+/src-bex/js/core
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -201,9 +201,9 @@ export default function ({ ssrContext }) {
         immediate: true,
         handler () {
           if (!this.value) {
-            this.standard = this.defaultStandard 
+            this.standard = this.defaultStandard
           } else {
-            let standard = this.defaultStandard 
+            let standard = this.defaultStandard
             switch (true) {
               case this.value.indexOf('-') !== -1: standard = 'iso'; break
               case this.value.indexOf('/') !== -1: standard = 'quasar'; break
@@ -292,9 +292,9 @@ export default function ({ ssrContext }) {
           let current = this.standard === 'quasar' ? this.values.quasar : this.values.iso
           if (force || current !== this.value) {
             let proporsal = this.value
-            if (this.standard === 'iso')
-              proporsal = proporsal.replace(/-/g, '/').replace('T', ' ')
-            let parts = proporsal.split(' ')
+            if (this.standard === 'quasar')
+              proporsal = proporsal.replace('/', /-/g).replace(' ', 'T')
+            let parts = proporsal.split('T')
             if (parts.length === 1) {
               let today = date.getDefault({ mode: this.mode })
               switch (this.mode) {
@@ -318,7 +318,7 @@ export default function ({ ssrContext }) {
         if (!value) {
           this.$emit('input', '')
         } else {
-          let proporsal = date.quasar({ 
+          let proporsal = date.quasar({
             base: this.value,
             masked: value,
             ampm: this.format24h ? void 0 : this.values.suffix,

--- a/src/component/QDatetimePicker.js
+++ b/src/component/QDatetimePicker.js
@@ -278,6 +278,13 @@ export default function ({ ssrContext }) {
           })
         }
         let current = this.standard === 'quasar' ? this.values.quasar : this.values.iso
+        if (this.standard === 'iso') {
+          if (this.mode === 'time'){
+            current = current.split('T')[1]
+          } else if (this.mode === 'date'){
+            current = current.split('T')[0]
+          }
+        }
         this.$emit('input', current)
       },
       __updateValue (force = false) {


### PR DESCRIPTION
When using 'date' or 'time' mode, the component modifes the data so that the data no longer is only 'date' or 'time'.
When using 'date' mode, initialy the data is for example '2021-05-12', but the component changes the data to '2021-05-12:00:00' or '2021-05-12:00:00:00' (when with-seconds is used). This is not good when working with data in a code that expects '2021-05-12' some problems arise - we need to strip the time again and again.
Similarly in time 'mode'.

I tried to solve this for the 'iso' standard and it works well. Did not try to do the same for 'quasar' standard, but it can be pretty the same.